### PR TITLE
Update JSON link, add Uniform and Stubborn

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This is an [Awesome List](https://awesome.re) for the Jai programming language. 
  * **Utilities**
    * [Magic](https://github.com/smari/jai-magic) - libmagic bindings.
    * [Uniform](https://github.com/rluba/uniform) - Fully-featured regular expression library.
+ * **Testing**
+   * [Stubborn](https://github.com/rluba/stubborn) – Minimal test runner and assertion library.
 
 
 ## Example code

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ This is an [Awesome List](https://awesome.re) for the Jai programming language. 
    * [Redis](https://github.com/smari/jai-redis)
  * **File formats**
    * [INI](https://github.com/smari/jai-ini) - INI file reader/writer.
-   * [JSON](https://github.com/rluba/jai-json) - JSON reader/writer.
+   * [JSON](https://github.com/rluba/jason) - JSON reader/writer.
  * **Utilities**
    * [Magic](https://github.com/smari/jai-magic) - libmagic bindings.
+   * [Uniform](https://github.com/rluba/uniform) - Fully-featured regular expression library.
 
 
 ## Example code


### PR DESCRIPTION
* I’ve recently renamed my JSON library and therefore updated the link to it.
* Added Uniform, a regular expression library. (It’s still crippled by a compiler bug, but it might nonetheless be useful already.)
* Added Stubborn, a minimal test runner and assertion library. It is still pretty minimal, but it’s already useful for automatically enumerating and running tests (at compile- or runtime).